### PR TITLE
Removed a few unneeded allocations

### DIFF
--- a/src/joshua/decoder/DecoderThread.java
+++ b/src/joshua/decoder/DecoderThread.java
@@ -94,15 +94,14 @@ public class DecoderThread extends Thread {
    */
   public Translation translate(Sentence sentence) {
 
-    Decoder.LOG(1, String.format("Input %d: %s", sentence.id(), sentence.fullSource()));
+    Decoder.LOG(1, "Input " + sentence.id() + ", " + sentence.fullSource());
 
     if (sentence.target() != null)
-      Decoder.LOG(1, String.format("Input %d: Constraining to target sentence '%s'", 
-          sentence.id(), sentence.target()));
+      Decoder.LOG(1, "Input "+ sentence.id() +": Constraining to target sentence " + sentence.target());
 
     // skip blank sentences
     if (sentence.isEmpty()) {
-      Decoder.LOG(1, String.format("Translation %d: Translation took 0 seconds", sentence.id()));
+      Decoder.LOG(1, "Translation " + sentence.id() + ": Translation took 0 seconds");
       return new Translation(sentence, null, featureFunctions, joshuaConfiguration);
     }
     

--- a/src/joshua/decoder/chart_parser/Chart.java
+++ b/src/joshua/decoder/chart_parser/Chart.java
@@ -359,7 +359,7 @@ public class Chart {
         /* Use the updated ranks to assign the next rule and tail node. */
         Rule nextRule = rules.get(nextRanks[0] - 1);
         // HGNode[] nextAntNodes = new HGNode[state.antNodes.size()];
-        List<HGNode> nextAntNodes = new ArrayList<HGNode>();
+        List<HGNode> nextAntNodes = new ArrayList<HGNode>(state.antNodes.size());
         for (int x = 0; x < state.ranks.length - 1; x++)
           nextAntNodes.add(superNodes.get(x).nodes.get(nextRanks[x + 1] - 1));
 

--- a/src/joshua/decoder/chart_parser/CubePruneState.java
+++ b/src/joshua/decoder/chart_parser/CubePruneState.java
@@ -18,7 +18,6 @@
  */
 package joshua.decoder.chart_parser;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -41,8 +40,7 @@ public class CubePruneState implements Comparable<CubePruneState> {
     this.computeNodeResult = score;
     this.ranks = ranks;
     this.rules = rules;
-    // create a new vector is critical, because currentAntecedents will change later
-    this.antNodes = new ArrayList<HGNode>(antecedents);
+    this.antNodes = antecedents;
     this.dotNode = dotNode;
   }
 

--- a/src/joshua/decoder/hypergraph/HyperEdge.java
+++ b/src/joshua/decoder/hypergraph/HyperEdge.java
@@ -41,7 +41,7 @@ public class HyperEdge {
    * this remembers the stateless + non_stateless logP assocated with the rule (excluding the
    * best-logP from ant nodes)
    * */
-  private Float transitionScore = null;
+  private float transitionScore;
 
   private Rule rule;
 
@@ -79,17 +79,13 @@ public class HyperEdge {
   }
 
   public float getTransitionLogP(boolean forceCompute) {
-    StringBuilder sb = new StringBuilder();
-    if (forceCompute || transitionScore == null) {
+    if (forceCompute) {
       float res = bestDerivationScore;
-      sb.append(String.format("Best derivation = %.5f", res));
       if (tailNodes != null) for (HGNode tailNode : tailNodes) {
         res += tailNode.bestHyperedge.bestDerivationScore;
-        sb.append(String.format(", tail = %.5f", tailNode.bestHyperedge.bestDerivationScore));
       }
       transitionScore = res;
     }
-    // System.err.println("HYPEREDGE SCORE = " + sb.toString());
     return transitionScore;
   }
 
@@ -100,9 +96,6 @@ public class HyperEdge {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append(this.rule);
-//    if (getTailNodes() != null) for (HGNode tailNode : getTailNodes()) {
-//      sb.append(" tail=" + tailNode);
-//    }
     return sb.toString();
   }
 }


### PR DESCRIPTION
This is the last commit from us targeting short lived object allocations.  I've separated this from the other commits because this line might warrant some discussion.

```
-    // create a new vector is critical, because currentAntecedents will change later
-    this.antNodes = new ArrayList<HGNode>(antecedents);
+    this.antNodes = antecedents;
```

When I look at the usages of this I don't see exactly why we need this new vector.  Is this comment still relevant?  This line creates a significant amount of objects during decoding which a. is slow, and b. causes a lot of garbage collection.  I can share some TLAB measurements for this method if anyone would like to dig into the details.  If there are any edge cases I'm missing we can leave this section as is.