### PR TITLE
Maven assembly plugin for executable jar with all dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,19 @@
           <target>1.8</target>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>org.apache.joshua.decoder.JoshuaDecoder</mainClass>
+            </manifest>
+          </archive>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <dependencies>


### PR DESCRIPTION
Added Maven  Assembly plugin


As you know, this plugin helps to package all dependency for easier usage.

To package 

    mvn clean compile assembly:single

To run the default main class:

    java -jar target/joshua-*-jar-with-dependencies.jar

To run any other class in jar, specify the class name:

    java -cp target/joshua-*-jar-with-dependencies.jar org.apache.joshua.decoder.JoshuaDecoder

