### PR TITLE
bug fix: GrammarPacker.java

### DIFF
--- a/src/main/java/org/apache/joshua/tools/GrammarPacker.java
+++ b/src/main/java/org/apache/joshua/tools/GrammarPacker.java
@@ -359,7 +359,7 @@ public class GrammarPacker {
         }
         String[] alignment_entries = alignment_line.split("\\s");
         byte[] alignments = new byte[alignment_entries.length * 2];
-        if (alignment_entries.length != 0) {
+        if (alignment_line.length() > 0) {
           for (int i = 0; i < alignment_entries.length; i++) {
             String[] parts = alignment_entries[i].split("-");
             alignments[2 * i] = Byte.parseByte(parts[0]);


### PR DESCRIPTION
In line 360, the result of splitting an empty string is an array of length 1, so the conditional on line 362 will always be true, resulting in an exception if alignment_line is an empty string. Having the conditional check the length of alignment_line instead solves this.