### PR TITLE
Added option to fire a dense language model oov indicator feature 

### DIFF
--- a/jni/kenlm_wrap.cc
+++ b/jni/kenlm_wrap.cc
@@ -114,6 +114,8 @@ public:
   // Returns the internal lm::WordIndex for a string
   virtual uint GetLmId(const StringPiece& word) const = 0;
 
+  virtual bool IsLmOov(const int joshua_id) const = 0;
+
   virtual bool IsKnownWordIndex(const lm::WordIndex& id) const = 0;
 
   virtual float ProbRule(jlong *begin, jlong *end, lm::ngram::ChartState& state) const = 0;
@@ -173,6 +175,13 @@ public:
 
   uint GetLmId(const StringPiece& word) const {
     return m_.GetVocabulary().Index(word);
+  }
+
+  bool IsLmOov(const int joshua_id) const {
+    if (map_.size() <= joshua_id) {
+      return true;
+    }
+    return !IsKnownWordIndex(map_[joshua_id]);
   }
 
   bool IsKnownWordIndex(const lm::WordIndex& id) const {
@@ -406,6 +415,12 @@ JNIEXPORT jfloat JNICALL Java_org_apache_joshua_decoder_ff_lm_KenLM_probForStrin
   }
   return lm_base->ProbForWordIndexArray(values,
       values + length);
+}
+
+JNIEXPORT jboolean JNICALL Java_org_apache_joshua_decoder_ff_lm_KenLM_isLmOov(
+    JNIEnv *env, jclass, jlong pointer, jint word) {
+    const VirtualBase* lm_base = reinterpret_cast<const VirtualBase*>(pointer);
+    return lm_base->IsLmOov(word);
 }
 
 JNIEXPORT jboolean JNICALL Java_org_apache_joshua_decoder_ff_lm_KenLM_isKnownWord(

--- a/resources/lm_oov/joshua.config
+++ b/resources/lm_oov/joshua.config
@@ -1,0 +1,17 @@
+feature-function = LanguageModel -lm_type berkeleylm -lm_order 5 -lm_file resources/berkeley_lm/lm -oov_feature
+
+tm = thrax -owner pt -maxspan 12 -path resources/kbest_extraction/grammar
+tm = thrax -owner glue -maxspan -1 -path resources/kbest_extraction/glue-grammar
+
+top-n = 0
+
+#feature_function = WordPenalty
+feature_function = OOVPenalty
+
+# Model Weights ####
+
+lm_0 0
+lm_0_oov 1
+OOVPenalty 1
+tm_pt_0 0
+tm_glue 0

--- a/src/main/java/org/apache/joshua/decoder/ff/FeatureFunction.java
+++ b/src/main/java/org/apache/joshua/decoder/ff/FeatureFunction.java
@@ -281,7 +281,7 @@ public abstract class FeatureFunction {
   public static HashMap<String, String> parseArgs(String[] args) {
     HashMap<String, String> parsedArgs = new HashMap<String, String>();
     boolean lookingForValue = false;
-    String currentKey = "";
+    String currentKey = null;
     for (int i = 0; i < args.length; i++) {
 
       Pattern argKeyPattern = Pattern.compile("^-[a-zA-Z]\\S+");
@@ -303,6 +303,12 @@ public abstract class FeatureFunction {
           lookingForValue = false;
         }
       }
+    }
+    
+    // make sure we add the last key without value
+    if (lookingForValue && currentKey != null) {
+      // end of line, no value
+      parsedArgs.put(currentKey, "");
     }
     return parsedArgs;
   }

--- a/src/main/java/org/apache/joshua/decoder/ff/lm/KenLM.java
+++ b/src/main/java/org/apache/joshua/decoder/ff/lm/KenLM.java
@@ -21,6 +21,7 @@ package org.apache.joshua.decoder.ff.lm;
 import org.apache.joshua.corpus.Vocabulary;
 import org.apache.joshua.decoder.ff.lm.NGramLanguageModel;
 import org.apache.joshua.decoder.ff.state_maintenance.KenLMState;
+import org.apache.joshua.util.FormatUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,6 +76,8 @@ public class KenLM implements NGramLanguageModel, Comparable<KenLM> {
   private final static native float probForString(long ptr, String[] words);
 
   private final static native boolean isKnownWord(long ptr, String word);
+  
+  private final static native boolean isLmOov(long ptr, int word);
 
   private final static native StateProbPair probRule(long ptr, long pool, long words[]);
   
@@ -183,6 +186,19 @@ public class KenLM implements NGramLanguageModel, Comparable<KenLM> {
   public String getStartSymbol() {
     return Vocabulary.START_SYM;
   }
+  
+  /**
+   * Returns whether the given Vocabulary ID is unknown to the
+   * KenLM vocabulary. This can be used for a LanguageModel_OOV features
+   * and does not need to convert to an intermediate string.
+   */
+  @Override
+  public boolean isOov(int wordId) {
+    if (FormatUtils.isNonterminal(wordId)) {
+      throw new IllegalArgumentException("Should not query for nonterminals!");
+    }
+    return isLmOov(pointer, wordId);
+  }
 
   public boolean isKnownWord(String word) {
     return isKnownWord(pointer, word);
@@ -230,4 +246,5 @@ public class KenLM implements NGramLanguageModel, Comparable<KenLM> {
   public float ngramLogProbability(int[] ngram) {
     return prob(ngram);
   }
+
 }

--- a/src/main/java/org/apache/joshua/decoder/ff/lm/NGramLanguageModel.java
+++ b/src/main/java/org/apache/joshua/decoder/ff/lm/NGramLanguageModel.java
@@ -70,4 +70,12 @@ public interface NGramLanguageModel {
   float ngramLogProbability(int[] ngram, int order);
 
   float ngramLogProbability(int[] ngram);
+  
+  /**
+   * Check whether a word corresponding to the given id is OOV to the language model.
+   * @param id Vocabulary id
+   * @return True if the word is OOV w.r.t language model training data
+   */
+  boolean isOov(int id);
+
 }

--- a/src/main/java/org/apache/joshua/decoder/ff/lm/StateMinimizingLanguageModel.java
+++ b/src/main/java/org/apache/joshua/decoder/ff/lm/StateMinimizingLanguageModel.java
@@ -80,9 +80,11 @@ public class StateMinimizingLanguageModel extends LanguageModelFF {
 
     // map to ken lm ids
     final long[] words = mapToKenLmIds(ruleWords, null, true);
-
+    
     // Get the probability of applying the rule and the new state
-    return weight * ((KenLM) languageModel).estimateRule(words);
+    float lmCost = weight * ((KenLM) languageModel).estimateRule(words);
+    float oovCost = oovWeight * ((withOovFeature) ? getOovs(ruleWords) : 0f);
+    return lmCost + oovCost;
   }
 
   /**
@@ -103,6 +105,11 @@ public class StateMinimizingLanguageModel extends LanguageModelFF {
       ruleWords = getTags(rule, i, j, sentence);
     } else {
       ruleWords = getRuleIds(rule);
+    }
+    
+    // Record the oov count
+    if (withOovFeature) {
+      acc.add(oovDenseFeatureIndex, getOovs(ruleWords));
     }
 
      // map to ken lm ids

--- a/src/main/java/org/apache/joshua/decoder/ff/lm/berkeley_lm/LMGrammarBerkeley.java
+++ b/src/main/java/org/apache/joshua/decoder/ff/lm/berkeley_lm/LMGrammarBerkeley.java
@@ -112,6 +112,12 @@ public class LMGrammarBerkeley extends DefaultNGramLanguageModel {
 
     return false;
   }
+  
+  @Override
+  public  boolean isOov(int id) {
+    // for Berkeley, we unfortunately have to temporarily convert to String
+    return lm.getWordIndexer().getIndexPossiblyUnk(Vocabulary.word(id)) <= 0;
+  };
 
   @Override
   public float sentenceLogProbability(int[] sentence, int order, int startIndex) {

--- a/src/main/java/org/apache/joshua/decoder/ff/lm/bloomfilter_lm/BloomFilterLanguageModel.java
+++ b/src/main/java/org/apache/joshua/decoder/ff/lm/bloomfilter_lm/BloomFilterLanguageModel.java
@@ -557,4 +557,11 @@ public class BloomFilterLanguageModel extends DefaultNGramLanguageModel implemen
     }
     return wittenBell(lm_ngram, order);
   }
+
+  @Override
+  public boolean isOov(int id) {
+    int[] ngram = new int[] {id};
+    int MAX_QCOUNT = getCount(ngram, ngram.length - 1, ngram.length, maxQ);
+    return (MAX_QCOUNT == 0);
+  }
 }

--- a/src/main/java/org/apache/joshua/decoder/ff/lm/buildin_lm/TrieLM.java
+++ b/src/main/java/org/apache/joshua/decoder/ff/lm/buildin_lm/TrieLM.java
@@ -29,11 +29,11 @@ import java.util.Map;
 import java.util.Scanner;
 
 import org.apache.joshua.corpus.Vocabulary;
-import  org.apache.joshua.decoder.ff.lm.AbstractLM;
-import  org.apache.joshua.decoder.ff.lm.ArpaFile;
-import  org.apache.joshua.decoder.ff.lm.ArpaNgram;
-import  org.apache.joshua.util.Bits;
-import  org.apache.joshua.util.Regex;
+import org.apache.joshua.decoder.ff.lm.AbstractLM;
+import org.apache.joshua.decoder.ff.lm.ArpaFile;
+import org.apache.joshua.decoder.ff.lm.ArpaNgram;
+import org.apache.joshua.util.Bits;
+import org.apache.joshua.util.Regex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -327,5 +327,9 @@ public class TrieLM extends AbstractLM { //DefaultNGramLanguageModel {
 
   }
 
+  @Override
+  public boolean isOov(int id) {
+    throw new RuntimeException("Not implemented!");
+  }
 
 }

--- a/src/test/java/org/apache/joshua/decoder/ff/lm/berkeley_lm/LMBerkeleySentenceProbablityTest.java
+++ b/src/test/java/org/apache/joshua/decoder/ff/lm/berkeley_lm/LMBerkeleySentenceProbablityTest.java
@@ -18,11 +18,16 @@
  */
 package org.apache.joshua.decoder.ff.lm.berkeley_lm;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
 import edu.berkeley.nlp.lm.ArrayEncodedNgramLanguageModel;
+
+import org.apache.joshua.corpus.Vocabulary;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
+
+import static org.testng.Assert.assertEquals;
 
 public class LMBerkeleySentenceProbablityTest {
 
@@ -43,5 +48,17 @@ public class LMBerkeleySentenceProbablityTest {
 
     float result = grammar.sentenceLogProbability(new int[] {0, 2, 3, 0}, 2, 0);
     assertEquals(expected, result, 0.0);
+  }
+  
+  @Test
+  public void givenUnknownWord_whenIsOov_thenCorrectlyDetected() {
+    LMGrammarBerkeley lm = new LMGrammarBerkeley(2, "resources/berkeley_lm/lm");
+    assertTrue(lm.isOov(Vocabulary.id("UNKNOWN_WORD")));
+    assertFalse(lm.isOov(Vocabulary.id("chat-rooms")));
+  }
+  
+  @AfterMethod
+  public void tearDown() {
+    Vocabulary.clear();
   }
 }

--- a/src/test/java/org/apache/joshua/system/KenLmTest.java
+++ b/src/test/java/org/apache/joshua/system/KenLmTest.java
@@ -80,6 +80,18 @@ public class KenLmTest {
     assertTrue(kenLm.isKnownWord("Wayne"));
     assertFalse(kenLm.isKnownWord("Wayne2222"));
   }
+  
+  @Test
+  public void givenKenLm_whenIsLmOov_thenResultsAreCorrect() {
+    KenLM kenLm = new KenLM(LANGUAGE_MODEL_PATH);
+    registerLanguageModel(kenLm);
+    int id = Vocabulary.id("Wayne");
+    int id2 = Vocabulary.id("wekjfhaew;jvnae;goiawehco;eiwnf;oi");
+    assertTrue(kenLm.isKnownWord(Vocabulary.word(id)));
+    assertFalse(kenLm.isKnownWord(Vocabulary.word(id2)));
+    assertFalse(kenLm.isOov(id));
+    assertTrue(kenLm.isOov(id2));
+  }
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/java/org/apache/joshua/system/LmOovFeatureTest.java
+++ b/src/test/java/org/apache/joshua/system/LmOovFeatureTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+ package org.apache.joshua.system;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.apache.joshua.decoder.Decoder;
+import org.apache.joshua.decoder.JoshuaConfiguration;
+import org.apache.joshua.decoder.Translation;
+import org.apache.joshua.decoder.segment_file.Sentence;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class LmOovFeatureTest {
+
+  private static final String CONFIG = "resources/lm_oov/joshua.config";
+  private static final String INPUT = "a chat-rooms full";
+  // expecting 2 lm oovs ('a' & 'full') and 2 grammar OOVs ('chat-rooms' & 'full') and score -198.000
+  private static final String EXPECTED_FEATURES = "tm_pt_0=-2.000 tm_glue_0=3.000 lm_0=-206.718 lm_0_oov=2.000 OOVPenalty=-200.000 | -198.000";
+
+  private JoshuaConfiguration joshuaConfig = null;
+  private Decoder decoder = null;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    joshuaConfig = new JoshuaConfiguration();
+    joshuaConfig.readConfigFile(CONFIG);
+    joshuaConfig.outputFormat = "%f | %c";
+    decoder = new Decoder(joshuaConfig, "");
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    decoder.cleanUp();
+    decoder = null;
+  }
+
+  @Test
+  public void givenInputWithDifferntOovTypes_whenDecode_thenFeaturesAreAsExpected() throws IOException {
+    final String translation = decode(INPUT).toString().trim();
+    System.out.println(translation);
+    assertEquals(translation, EXPECTED_FEATURES);
+  }
+
+  private Translation decode(String input) {
+    final Sentence sentence = new Sentence(input, 0, joshuaConfig);
+    return decoder.decode(sentence);
+  }
+
+}


### PR DESCRIPTION
from LanguageModelFF. By default it is turned off. To activate, specify '-oov_feature' in the lm line in joshua.config.
This OOV feature is different from the OOV rules in Joshua grammars/phrase tables. It indicates an OOV in the language model which typically has a much larger vocabulary.