### PR TITLE
JOSHUA-279 Skip tests that rely on KenLM when KenLM is not present.

### DIFF
--- a/src/test/java/org/apache/joshua/decoder/ff/lm/class_lm/ClassBasedLanguageModelTest.java
+++ b/src/test/java/org/apache/joshua/decoder/ff/lm/class_lm/ClassBasedLanguageModelTest.java
@@ -28,10 +28,14 @@ import org.apache.joshua.decoder.ff.FeatureVector;
 import org.apache.joshua.decoder.ff.lm.LanguageModelFF;
 import org.apache.joshua.decoder.ff.tm.OwnerMap;
 import org.apache.joshua.decoder.ff.tm.Rule;
+import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+/**
+ * This unit test relies on KenLM.  If the KenLM library is not found when the test is run all tests will be skipped.
+ */
 public class ClassBasedLanguageModelTest {
 
   private static final float WEIGHT = 0.5f;
@@ -49,7 +53,12 @@ public class ClassBasedLanguageModelTest {
       "-class_map", "./src/test/resources/lm/class_lm/class.map" };
 
     JoshuaConfiguration config = new JoshuaConfiguration();
-    ff = new LanguageModelFF(weights, args, config);
+    try {
+      ff = new LanguageModelFF(weights, args, config);
+    } catch (ExceptionInInitializerError kenLmException) {
+      throw new SkipException("Skipping test because KenLM.so/dylib was not found");
+    }
+
   }
 
   @AfterMethod


### PR DESCRIPTION
For unit tests that rely on KenLM I'm going to try and convert them all to follow this pattern.  We'll initialize the unit of work in the setup, and catch the usual exception kenlm throws when the library is not found.  We'll then swallow the exception and rethrow an exception indicating to testng that the test should be skipped.  This way on systems that don't have the KenLM binaries the test will be skipped without failing, and on systems that do have KenLM the test will be properly run.

I've run this with 'mvn' and 'mvn clean install' and both are working for me with/without KenLM.