### PR TITLE
JOSHUA-286 - Replace old joshua-decoder.org links with joshua.apache.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ doxygen_*.tmp
 .cachepipe
 
 joshua-decoder.org
+joshua.apache.org
 release
 
 scripts/training/MGIZA/

--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,6 @@ doxygen_*.tmp
 *.so
 .cachepipe
 
-joshua-decoder.org
-joshua.apache.org
 release
 
 scripts/training/MGIZA/

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -139,7 +139,7 @@ They include:
 
 - Significantly improved and expanded documentation (both user and developer)
 
-  See http://apache.joshua.org/4.0 or ./apache.joshua.org/4.0/index.html (local mirror)
+  See http://joshua-decoder.org/4.0 or ./joshua-decoder.org/4.0/index.html (local mirror)
 
 - Synchronous parsing
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -139,7 +139,7 @@ They include:
 
 - Significantly improved and expanded documentation (both user and developer)
 
-  See http://joshua-decoder.org/4.0 or ./joshua-decoder.org/4.0/index.html (local mirror)
+  See http://apache.joshua.org/4.0 or ./apache.joshua.org/4.0/index.html (local mirror)
 
 - Synchronous parsing
 

--- a/scripts/support/make-release.sh
+++ b/scripts/support/make-release.sh
@@ -40,7 +40,6 @@ echo "Bundling up joshua-$version"
 [[ ! -d release ]] && mkdir release
 rm -f joshua-$version && ln -s $JOSHUA joshua-$version
 
-wget -r http://joshua.apache.org/6.0/
 
 tar czf release/joshua-$version.tgz \
     --exclude='*~' --exclude='#*' \
@@ -54,7 +53,6 @@ tar czf release/joshua-$version.tgz \
     joshua-$version/test \
     joshua-$version/examples \
     joshua-$version/thrax/bin/thrax.jar \
-    joshua-$version/joshua.apache.org
 
 ln -sf joshua-$version release/joshua-runtime-$version
 tar czf release/joshua-runtime-$version.tgz \
@@ -67,7 +65,6 @@ tar czf release/joshua-runtime-$version.tgz \
     joshua-runtime-$version/lib/{ant*,jung*,junit*jar,README,LICENSES} \
     joshua-runtime-$version/scripts \
     joshua-runtime-$version/examples \
-    joshua-runtime-$version/joshua.apache.org
 
 rm -f joshua-$version
 rm -f VERSION

--- a/scripts/support/make-release.sh
+++ b/scripts/support/make-release.sh
@@ -40,7 +40,7 @@ echo "Bundling up joshua-$version"
 [[ ! -d release ]] && mkdir release
 rm -f joshua-$version && ln -s $JOSHUA joshua-$version
 
-wget -r http://joshua-decoder.org/
+wget -r http://joshua.apache.org/6.0/
 
 tar czf release/joshua-$version.tgz \
     --exclude='*~' --exclude='#*' \
@@ -54,7 +54,7 @@ tar czf release/joshua-$version.tgz \
     joshua-$version/test \
     joshua-$version/examples \
     joshua-$version/thrax/bin/thrax.jar \
-    joshua-$version/joshua-decoder.org
+    joshua-$version/joshua.apache.org
 
 ln -sf joshua-$version release/joshua-runtime-$version
 tar czf release/joshua-runtime-$version.tgz \
@@ -67,7 +67,7 @@ tar czf release/joshua-runtime-$version.tgz \
     joshua-runtime-$version/lib/{ant*,jung*,junit*jar,README,LICENSES} \
     joshua-runtime-$version/scripts \
     joshua-runtime-$version/examples \
-    joshua-runtime-$version/joshua-decoder.org
+    joshua-runtime-$version/joshua.apache.org
 
 rm -f joshua-$version
 rm -f VERSION

--- a/src/main/java/org/apache/joshua/decoder/Decoder.java
+++ b/src/main/java/org/apache/joshua/decoder/Decoder.java
@@ -496,7 +496,7 @@ public class Decoder {
           errMsg.append("FATAL: Invalid feature weight line found in config file.\n");
           errMsg.append(String.format("The line was '%s'\n", pairStr));
           errMsg.append("You might be using an old version of the config file that is no longer supported\n");
-          errMsg.append("Check joshua-decoder.org or email joshua_support@googlegroups.com for help\n");
+          errMsg.append("Check joshua.apache.org or email joshua_support@googlegroups.com for help\n");
           errMsg.append("Code = " + 17);
           throw new RuntimeException(errMsg.toString());
         }

--- a/src/main/java/org/apache/joshua/decoder/Decoder.java
+++ b/src/main/java/org/apache/joshua/decoder/Decoder.java
@@ -496,7 +496,7 @@ public class Decoder {
           errMsg.append("FATAL: Invalid feature weight line found in config file.\n");
           errMsg.append(String.format("The line was '%s'\n", pairStr));
           errMsg.append("You might be using an old version of the config file that is no longer supported\n");
-          errMsg.append("Check joshua.apache.org or email joshua_support@googlegroups.com for help\n");
+          errMsg.append("Check joshua.apache.org or email dev@joshua.apache.org for help\n");
           errMsg.append("Code = " + 17);
           throw new RuntimeException(errMsg.toString());
         }

--- a/src/main/java/org/apache/joshua/decoder/ff/lm/KenLM.java
+++ b/src/main/java/org/apache/joshua/decoder/ff/lm/KenLM.java
@@ -49,7 +49,7 @@ public class KenLM implements NGramLanguageModel, Comparable<KenLM> {
       LOG.error("*        Make sure that BOOST_ROOT is set to the root of your boost");
       LOG.error("*        installation (it's not /opt/local/, the default), change to");
       LOG.error("*        $JOSHUA, and type 'ant kenlm'. If problems persist, see the");
-      LOG.error("*        website (joshua-decoder.org)."); //FIXME: update link to newer url
+      LOG.error("*        website (joshua.apache.org)."); 
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
- Update links to documentation and support to reflect the 
move to Apache. 
- keep Gitignore entry for old website was kept to keep the 
repo clean. 
- Update links to the git repo as well.
- old pages in the `docs` folder unchanged. 