### PR TITLE
JOSHUA-301 - Add findbugs plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,9 @@
 
   <properties>
     <slf4j.version>1.7.21</slf4j.version>
+    <findbugs.version>3.0.4</findbugs.version>
   </properties>
+
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
@@ -120,6 +122,24 @@
     <testOutputDirectory>${basedir}/target/test-classes</testOutputDirectory>
     <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
     <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>findbugs-maven-plugin</artifactId>
+          <version>${findbugs.version}</version>
+          <configuration>
+            <xmlOutput>true</xmlOutput>
+            <effort>Max</effort>
+            <failOnError>true</failOnError>
+            <includeTests>true</includeTests>
+            <maxRank>16</maxRank>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -168,6 +188,11 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>${findbugs.version}</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Currently this can be run with 'mvn findbugs:check'. There are a ton of warnings, however,
which currently fail the build if this is run as part of the maven build. Perhaps once fixed this auto-build failure can be added in, but at present there are too many warnings to fix at present.