### PR TITLE
Fix Travis-CI by adding a step to install ant on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
     - os: osx
       osx_image: xcode8
       before_install:
+      - brew update
+      - brew install ant
       - export JOSHUA=`pwd`
       - export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
       - ./download-deps.sh


### PR DESCRIPTION
It looks like the download-deps.sh now requires ant to build BerkleyLM?  If so feel free to merge this, it should make sure the OSX image has ant installed before building.