### PR TITLE
fix basedir path for java.library.path

### DIFF
--- a/joshua-core/pom.xml
+++ b/joshua-core/pom.xml
@@ -91,7 +91,7 @@
         <version>2.19.1</version>
         <configuration>
           <forkMode>once</forkMode>
-          <argLine>-Djava.library.path=${project.basedir}/lib</argLine>
+          <argLine>-Djava.library.path=${project.basedir}/../lib</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
makes unit tests run with kenlm again