### PR TITLE
Changes to improve performance of KenLM

### DIFF
--- a/jni/kenlm_wrap.cc
+++ b/jni/kenlm_wrap.cc
@@ -92,11 +92,12 @@ class Chart {
       if (!ins.second) {
         vec_.pop_back();
       }
-      return *ins.first;
+      return *ins.first + 1; // +1 so that the first id is 1, not 0.  We use sign bit to 
+                             // distinguish ChartState from vocab id.  
     }
 
     const lm::ngram::ChartState &InterpretState(StateIndex index) const {
-      return vec_[index];
+      return vec_[index - 1];
     }
 
   private:

--- a/src/main/java/org/apache/joshua/decoder/KenLMPool.java
+++ b/src/main/java/org/apache/joshua/decoder/KenLMPool.java
@@ -1,0 +1,42 @@
+package org.apache.joshua.decoder;
+
+import org.apache.joshua.decoder.ff.lm.KenLM;
+
+/**
+ * Class to wrap a KenLM pool of states.  This class is not ThreadSafe.  It should be
+ * used in a scoped context, and close must be called to release native resources.  It
+ * does implement a custom finalizer that will release these resources if needed, but
+ * this should not be relied on.
+ *
+ * @author Kellen Sunderland
+ */
+
+public class KenLMPool implements AutoCloseable {
+
+  private final long pool;
+  private final KenLM languageModel;
+  private boolean released = false;
+
+  public KenLMPool(long pool, KenLM languageModel) {
+    this.pool = pool;
+    this.languageModel = languageModel;
+  }
+
+  public long getPool() {
+    return pool;
+  }
+
+  @Override
+  protected void finalize() throws Throwable {
+    close();
+    super.finalize();
+  }
+
+  @Override
+  public void close() {
+    if (!released) {
+      released = true;
+      languageModel.destroyLMPool(pool);
+    }
+  }
+}

--- a/src/main/java/org/apache/joshua/decoder/LanguageModelStateManager.java
+++ b/src/main/java/org/apache/joshua/decoder/LanguageModelStateManager.java
@@ -1,0 +1,29 @@
+package org.apache.joshua.decoder;
+
+import org.apache.joshua.decoder.ff.lm.KenLM;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * @author Kellen Sunderland
+ */
+public class LanguageModelStateManager {
+
+  private Map<UUID, KenLMPool> languageModelPoolMapping = new HashMap<>();
+
+  public KenLMPool getStatePool(UUID languageModelId, KenLM languageModel) {
+    KenLMPool statePool = languageModelPoolMapping.get(languageModelId);
+    if (statePool == null) {
+      statePool = languageModel.createLMPool();
+      languageModelPoolMapping.put(languageModelId, statePool);
+    }
+    return statePool;
+  }
+
+  public void clearStatePool() {
+    languageModelPoolMapping.values().forEach(KenLMPool::close);
+    languageModelPoolMapping.clear();
+  }
+}

--- a/src/main/java/org/apache/joshua/decoder/Translation.java
+++ b/src/main/java/org/apache/joshua/decoder/Translation.java
@@ -182,8 +182,8 @@ public class Translation {
 
     }
 
-    // remove state from StateMinimizingLanguageModel instances in features.
-    destroyKenLMStates(featureFunctions);
+    // Force any StateMinimizingLanguageModel pool mappings to be cleaned
+    source.getStateManager().clearStatePool();
 
   }
 
@@ -223,18 +223,5 @@ public class Translation {
           "No StructuredTranslation objects created. You should set JoshuaConfigration.use_structured_output = true");
     }
     return structuredTranslations;
-  }
-
-  /**
-   * KenLM hack. If using KenLMFF, we need to tell KenLM to delete the pool used to create chart
-   * objects for this sentence.
-   */
-  private void destroyKenLMStates(final List<FeatureFunction> featureFunctions) {
-    for (FeatureFunction feature : featureFunctions) {
-      if (feature instanceof StateMinimizingLanguageModel) {
-        ((StateMinimizingLanguageModel) feature).destroyPool(getSourceSentence().id());
-        break;
-      }
-    }
   }
 }

--- a/src/main/java/org/apache/joshua/decoder/ff/lm/StateMinimizingLanguageModel.java
+++ b/src/main/java/org/apache/joshua/decoder/ff/lm/StateMinimizingLanguageModel.java
@@ -21,10 +21,11 @@ package org.apache.joshua.decoder.ff.lm;
 import static org.apache.joshua.util.FormatUtils.isNonterminal;
 
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.UUID;
 
 import org.apache.joshua.corpus.Vocabulary;
 import org.apache.joshua.decoder.JoshuaConfiguration;
+import org.apache.joshua.decoder.KenLMPool;
 import org.apache.joshua.decoder.chart_parser.SourcePath;
 import org.apache.joshua.decoder.ff.FeatureVector;
 import org.apache.joshua.decoder.ff.lm.KenLM.StateProbPair;
@@ -41,9 +42,6 @@ import org.apache.joshua.decoder.segment_file.Sentence;
  * @author Juri Ganitkevitch juri@cs.jhu.edu
  */
 public class StateMinimizingLanguageModel extends LanguageModelFF {
-
-  // maps from sentence numbers to KenLM-side pools used to allocate state
-  private static final ConcurrentHashMap<Integer, Long> poolMap = new ConcurrentHashMap<>();
 
   public StateMinimizingLanguageModel(FeatureVector weights, String[] args, JoshuaConfiguration config) {
     super(weights, args, config);
@@ -87,6 +85,8 @@ public class StateMinimizingLanguageModel extends LanguageModelFF {
     return lmCost + oovCost;
   }
 
+  private UUID languageModelPoolId = UUID.randomUUID();
+
   /**
    * Computes the features incurred along this edge. Note that these features are unweighted costs
    * of the feature; they are the feature cost, not the model cost, or the inner product of them.
@@ -115,14 +115,11 @@ public class StateMinimizingLanguageModel extends LanguageModelFF {
      // map to ken lm ids
     final long[] words = mapToKenLmIds(ruleWords, tailNodes, false);
 
-    final int sentID = sentence.id();
-    // Since sentId is unique across threads, next operations are safe, but not atomic!
-    if (!poolMap.containsKey(sentID)) {
-      poolMap.put(sentID, ((KenLM) languageModel).createLMPool());
-    }
+    KenLMPool statePool = sentence.getStateManager().getStatePool(languageModelPoolId, (KenLM)
+            languageModel);
 
     // Get the probability of applying the rule and the new state
-    final StateProbPair pair = ((KenLM) languageModel).probRule(words, poolMap.get(sentID));
+    final StateProbPair pair = ((KenLM) languageModel).probRule(words, statePool);
 
     // Record the prob
     acc.add(denseFeatureIndex, pair.prob);
@@ -159,19 +156,6 @@ public class StateMinimizingLanguageModel extends LanguageModelFF {
       }
     }
     return kenIds;
-  }
-
-  /**
-   * Destroys the pool created to allocate state for this sentence. Called from the
-   * {@link org.apache.joshua.decoder.Translation} class after outputting the sentence or k-best list. Hosting
-   * this map here in KenLMFF statically allows pools to be shared across KenLM instances.
-   *
-   * @param sentId a key in the poolmap table to destroy
-   */
-  public void destroyPool(int sentId) {
-    if (poolMap.containsKey(sentId))
-      ((KenLM) languageModel).destroyLMPool(poolMap.get(sentId));
-    poolMap.remove(sentId);
   }
 
   /**

--- a/src/main/java/org/apache/joshua/decoder/segment_file/Sentence.java
+++ b/src/main/java/org/apache/joshua/decoder/segment_file/Sentence.java
@@ -21,16 +21,21 @@ package org.apache.joshua.decoder.segment_file;
 import static org.apache.joshua.util.FormatUtils.addSentenceMarkers;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.StringTokenizer;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.joshua.corpus.Vocabulary;
 import org.apache.joshua.decoder.JoshuaConfiguration;
+import org.apache.joshua.decoder.KenLMPool;
+import org.apache.joshua.decoder.LanguageModelStateManager;
 import org.apache.joshua.decoder.ff.tm.Grammar;
 import org.apache.joshua.lattice.Arc;
 import org.apache.joshua.lattice.Lattice;
@@ -76,6 +81,8 @@ public class Sentence {
   private final List<ConstraintSpan> constraints;
   
   public JoshuaConfiguration config = null;
+
+  private LanguageModelStateManager stateManager = new LanguageModelStateManager();
 
   /**
    * Constructor. Receives a string representing the input sentence. This string may be a
@@ -446,5 +453,9 @@ public class Sentence {
 
   public Node<Token> getNode(int i) {
     return getLattice().getNode(i);
+  }
+
+  public LanguageModelStateManager getStateManager() {
+    return stateManager;
   }
 }

--- a/src/test/java/org/apache/joshua/system/KenLmTest.java
+++ b/src/test/java/org/apache/joshua/system/KenLmTest.java
@@ -84,6 +84,29 @@ public class KenLmTest {
   }
 
   @Test
+  public void givenKenLm_whenQueryingForNgramProbability1423_thenIdAndStringMethodsReturnTheSame() {
+    // GIVEN
+    KenLmTestUtil.Guard(() -> kenLm = new KenLM
+            ("/Users/kellens/Development/incubator-joshua/src/test/resources/kbest_extraction/lm.gz"));
+
+    registerLanguageModel(kenLm);
+    int[] words = Vocabulary.addAll("! burgher");
+    long[] longIds = new long[words.length];
+
+    for (int i = 0; i < words.length; i++) {
+      longIds[i] = words[i];
+    }
+
+    // WHEN
+    float probability = kenLm.prob(words);
+
+    KenLMPool pool = kenLm.createLMPool();
+    KenLM.StateProbPair probability2 = kenLm.probRule(longIds, pool);
+    pool.close();
+
+  }
+
+  @Test
   public void givenKenLm_whenQueryingWithState_thenStateAndProbReturned() {
     // GIVEN
     KenLmTestUtil.Guard(() -> kenLm = new KenLM(LANGUAGE_MODEL_PATH));
@@ -106,7 +129,7 @@ public class KenLmTest {
 
     // THEN
     assertThat(result, is(notNullValue()));
-    assertThat(result.state.getState(), is(0L));
+    assertThat(result.state.getState(), is(1L));
     assertThat(result.prob, is(-3.7906885f));
   }
 


### PR DESCRIPTION
This change cleans up the kenlm_wrap.cc file to get rid of the multimap that was recently added.  It replaces the multimap with a vector/unordered_set which should allow for faster lookups (and is also less code).  

Also included in this change is a modification to the probRule call that packs the state and probability returned from that call into 64 bits, which is then unpacked on the Java side.  This eliminates the need to reference a Java object across the JNI boundary.  

Finally the scope of Chart objects in KenLM is changed to be per sentence, per language model, which should guarantee that there are no crashes due to collisions.

Many thanks to @kpu for providing the ideas behind these optimizations.