### PR TITLE
JOSHUA-316 run_bundler.py returning JOB FAILED (return code 1) TypeError: memoryview: a bytes-like object is required, not 'str'

### DIFF
--- a/scripts/language-pack/README.template
+++ b/scripts/language-pack/README.template
@@ -44,7 +44,7 @@ You can then connect directly to the socket using nc or telnet:
 
     cat sentences.txt | prepare.sh | nc localhost 5674 > output.txt
 
-You can set the RESTful interface by also passing '-server-type http':
+You can set the RESTful interface by also passing `-server-type http`:
 
     joshua -server-port 5674 -server-type http
 

--- a/scripts/support/run_bundler.py
+++ b/scripts/support/run_bundler.py
@@ -94,7 +94,7 @@ options that may be useful during decoding include:
    complete target hypergraph until it is ready to be processed for output, so
    too many simultaneous threads could result in lots of memory usage if a long
    sentence results in many sentences being queued up. We have run Joshua with
-   as many as 48 threads without any problems of this kind, but it’s useful to
+   as many as 48 threads without any problems of this kind, but it's useful to
    keep in the back of your mind.
 
 -  `-pop-limit N`
@@ -199,7 +199,7 @@ def filter_through_copy_config_script(config_text, copy_configs):
         'Running the copy-config.pl script with the command: ' + cmd
     )
     p = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE)
-    result, err = p.communicate(config_text)
+    result, err = p.communicate(config_text.encode('utf8'))
     if p.returncode != 0:
         raise CalledProcessError(
             'Encountered an error running the copy-config.pl script.\n'
@@ -207,7 +207,7 @@ def filter_through_copy_config_script(config_text, copy_configs):
             '  error: %s'
             % (cmd, err or '')
         )
-    return result
+    return result.decode('utf8')
 
 
 def line_specifies_grammar(line):
@@ -748,7 +748,7 @@ def main(argv):
         operations = collect_operations(opts)
         execute_operations(operations)
     except Exception as e:
-        error_quit(e.message)
+        error_quit(str(e))
 
 
 if __name__ == "__main__":

--- a/scripts/support/run_bundler.py
+++ b/scripts/support/run_bundler.py
@@ -659,7 +659,7 @@ def collect_operations(opts):
                 message = (
                     # Prepend the line number to the error message
                     'ERROR: Configuration file "{0}" line {1}: {2}'
-                    .format(opts.config.name, line_num, e.message)
+                    .format(opts.config.name, line_num, str(e))
                 )
                 e.message = message
                 raise e
@@ -675,7 +675,7 @@ def collect_operations(opts):
                 # Prepend the line number to the error message
                 message = (
                     'ERROR: Configuration file "{0}" line {1}: {2}'
-                    .format(opts.config.name, line_num, e.message)
+                    .format(opts.config.name, line_num, str(e))
                 )
                 e.message = message
                 raise e

--- a/scripts/training/run_tuner.py
+++ b/scripts/training/run_tuner.py
@@ -350,7 +350,8 @@ def get_features(config_file):
 
     output = check_output("%s/bin/joshua-decoder -c %s -show-weights -v 0" % (JOSHUA, config_file), shell=True)
     features = []
-    for index, item in enumerate(output.split('\n')):
+    for index, item in enumerate(output.split('\n'.encode(encoding='utf_8', errors='strict'))):
+        item = item.decode()
         if item != "":
             features.append(tuple(item.split()))
     return features
@@ -388,7 +389,7 @@ def setup_configs(template, template_dest, target, num_refs, tunedir, command, c
                      'NUMREFS': num_refs,
                      'TUNEDIR': tunedir,
                      'METRIC': metric,
-                     'ITERATIONS': `iterations`,
+                     'ITERATIONS': iterations,
                      'DECODER_COMMAND': command,
                      'DECODER_CONFIG': config,
                      'DECODER_OUTPUT': output })
@@ -416,7 +417,7 @@ def run_zmert(tunedir, source, target, command, config, output, opts):
                   target, get_num_refs(target), tunedir, command, config, output,
                   opts.metric, opts.iterations or 10)
 
-    tuner_mem = '4g'
+    tuner_mem = '10g'
     call("java -d64 -Xmx%s -cp %s/target/joshua-*-jar-with-dependencies.jar org.apache.joshua.zmert.ZMERT -maxMem 4000 %s/mert.config > %s/mert.log 2>&1" % (tuner_mem, JOSHUA, tunedir, tunedir), shell=True)
 
     safe_symlink(os.path.join(os.path.dirname(config),'joshua.config.ZMERT.final'),
@@ -430,7 +431,7 @@ def run_pro(tunedir, source, target, command, config, output, opts):
                   target, get_num_refs(target), tunedir, command, config, output,
                   opts.metric, opts.iterations or 30)
 
-    tuner_mem = '4g'
+    tuner_mem = '10g'
     call("java -d64 -Xmx%s -cp %s/target/joshua-*-jar-with-dependencies.jar org.apache.joshua.pro.PRO %s/pro.config > %s/pro.log 2>&1" % (tuner_mem, JOSHUA, tunedir, tunedir), shell=True)
 
     safe_symlink(os.path.join(os.path.dirname(config),'joshua.config.PRO.final'),
@@ -444,7 +445,7 @@ def run_mira(tunedir, source, target, command, config, output, opts):
                   target, get_num_refs(target), tunedir, command, config, output,
                   opts.metric, opts.iterations or 5)
 
-    tuner_mem = '4g'
+    tuner_mem = '10g'
     call("java -d64 -Xmx%s -cp %s/target/joshua-*-jar-with-dependencies.jar org.apache.joshua.mira.MIRA %s/mira.config > %s/mira.log 2>&1" % (tuner_mem, JOSHUA, tunedir, tunedir), shell=True)
 
     safe_symlink(os.path.join(os.path.dirname(config),'joshua.config.MIRA.final'),
@@ -457,7 +458,7 @@ def run_adagrad(tunedir, source, target, command, config, output, opts):
                   target, get_num_refs(target), tunedir, command, config, output,
                   opts.metric, opts.iterations or 10)
 
-    tuner_mem = '4g'
+    tuner_mem = '10g'
     call("java -d64 -Xmx%s -cp %s/target/joshua-*-jar-with-dependencies.jar org.apache.joshua.adagrad.AdaGrad %s/adagrad.config > %s/adagrad.log 2>&1" % (tuner_mem, JOSHUA, tunedir, tunedir), shell=True)
 
     safe_symlink(os.path.join(os.path.dirname(config),'joshua.config.ADAGRAD.final'),


### PR DESCRIPTION
This issue addresses https://issues.apache.org/jira/browse/JOSHUA-316

This issue was a complete PITA. The non ascii character in run_bundler.py README template was a frigging big PITA.

Done now folks :)
