### PR TITLE
Tweaked Dockerfile to contain only jre 1.8 and to use mvn package

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM java:latest
+FROM maven:latest
 
 LABEL Description="This image is used to provide a Joshua Decoder environment" Vendor="Apache Software Foundation"
 
@@ -28,7 +28,7 @@ RUN apt-get update && \
             liblzma-dev \            
             libz-dev \
             make \
-            maven
+            ant
 
 
 RUN mkdir /opt/joshua
@@ -44,4 +44,4 @@ COPY . $JOSHUA
 
 RUN sh download-deps.sh
 
-RUN mvn clean compile assembly:single
+RUN mvn package


### PR DESCRIPTION
Just some small changes here.  I found when creating files with the previous version that is was often using java 1.7 for some reason.  Changed the base image partially to get an image that already has maven, and partly to make sure on jre 1.8 is installed. 

Also switched to mvn package.