### PR TITLE
Fix: memory overflow in tuning with larger language models

### DIFF
--- a/scripts/training/pipeline.pl
+++ b/scripts/training/pipeline.pl
@@ -173,6 +173,7 @@ my $NUM_JOBS = 1;
 # The number of threads to use at different pieces in the pipeline
 # (giza, decoding)
 my $NUM_THREADS = 1;
+$ENV{'NUM_THREADS'} = $NUM_THREADS;
 
 # which LM to use (kenlm or berkeleylm)
 my $LM_TYPE = "kenlm";

--- a/scripts/training/pipeline.pl
+++ b/scripts/training/pipeline.pl
@@ -135,6 +135,8 @@ my $FILTERING = "fast";
 # a lot more than this for SAMT decoding (though really it depends
 # mostly on your grammar size)
 my $JOSHUA_MEM = "4g";
+# export the environment var
+$ENV{'JOSHUA_MEM'} = $JOSHUA_MEM;
 
 # the amount of memory available for hadoop processes (passed to
 # Hadoop via -Dmapred.child.java.opts

--- a/scripts/training/run_tuner.py
+++ b/scripts/training/run_tuner.py
@@ -347,10 +347,11 @@ def parse_tm_line(line):
 def get_features(config_file):
     """Queries the decoder for all dense features that will be fired by the feature
     functions activated in the config file"""
-
-    mem_size = os.environ.get('JOSHUA_MEM', None)
-    mem_arg = '-m %s' % mem_size if mem_size else ''
+    
+    mem_arg = '-m %s' % os.environ['JOSHUA_MEM'] if 'JOSHUA_MEM' in os.environ else ''
     decode_cmd = "%s/bin/joshua-decoder %s -c %s -show-weights -v 0" % (JOSHUA, mem_arg, config_file)
+    if 'NUM_THREADS' in os.environ:
+        decode_cmd += ' -threads %s' % os.environ['NUM_THREADS']
     output = check_output(decode_cmd, shell=True)
     features = []
     for index, item in enumerate(output.split('\n'.encode(encoding='utf_8', errors='strict'))):

--- a/scripts/training/run_tuner.py
+++ b/scripts/training/run_tuner.py
@@ -348,7 +348,10 @@ def get_features(config_file):
     """Queries the decoder for all dense features that will be fired by the feature
     functions activated in the config file"""
 
-    output = check_output("%s/bin/joshua-decoder -c %s -show-weights -v 0" % (JOSHUA, config_file), shell=True)
+    mem_size = os.environ.get('JOSHUA_MEM', None)
+    mem_arg = '-m %s' % mem_size if mem_size else ''
+    decode_cmd = "%s/bin/joshua-decoder %s -c %s -show-weights -v 0" % (JOSHUA, mem_arg, config_file)
+    output = check_output(decode_cmd, shell=True)
     features = []
     for index, item in enumerate(output.split('\n'.encode(encoding='utf_8', errors='strict'))):
         item = item.decode()


### PR DESCRIPTION
tuner needs more memory when larger language models are used.
Even though we allocate more memory in the training pipeline script
the value is ignored at one place in pipeline.

This PR fixes it by exporting env var, and passing it to the JVM at the right place

EDIT: also connected `$NUM_THREADS` variable in `pipeline.pl` to  the `-threads` CLI argument of decoder